### PR TITLE
fix: KeyError when error happens in library

### DIFF
--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -651,11 +651,9 @@ class VyperContract(_BaseVyperContract):
             # TODO: figure out why fn is None.
             return None
 
-        signatures = self.compiler_data.function_signatures
-        if fn.name not in signatures:
-            return None  # todo: recurse into imported libraries
+        fn_t = fn._metadata["func_type"]
 
-        frame_info = signatures[fn.name]._ir_info.frame_info
+        frame_info = fn_t._ir_info.frame_info
 
         mem = computation._memory
         frame_detail = FrameDetail(fn.name)

--- a/boa/contracts/vyper/vyper_contract.py
+++ b/boa/contracts/vyper/vyper_contract.py
@@ -651,7 +651,11 @@ class VyperContract(_BaseVyperContract):
             # TODO: figure out why fn is None.
             return None
 
-        frame_info = self.compiler_data.function_signatures[fn.name]._ir_info.frame_info
+        signatures = self.compiler_data.function_signatures
+        if fn.name not in signatures:
+            return None  # todo: recurse into imported libraries
+
+        frame_info = signatures[fn.name]._ir_info.frame_info
 
         mem = computation._memory
         frame_detail = FrameDetail(fn.name)

--- a/examples/ERC20.vy
+++ b/examples/ERC20.vy
@@ -1,3 +1,4 @@
+# pragma version ^0.4.0
 # @dev Implementation of ERC-20 token standard.
 # @author Takayuki Jimba (@yudetamago)
 # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md

--- a/tests/unitary/fixtures/module_contract.vy
+++ b/tests/unitary/fixtures/module_contract.vy
@@ -1,0 +1,7 @@
+# pragma version ^0.4.0
+import module_lib
+
+@external
+@view
+def fail():
+    module_lib.throw()

--- a/tests/unitary/fixtures/module_lib.vy
+++ b/tests/unitary/fixtures/module_lib.vy
@@ -1,0 +1,6 @@
+# pragma version ~=0.4.0
+
+@internal
+@view
+def throw():
+    raise "Error with message"

--- a/tests/unitary/test_modules.py
+++ b/tests/unitary/test_modules.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+import boa
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_throw():
+    c = boa.load(FIXTURES / "module_contract.vy")
+    with boa.reverts("Error with message"):
+        c.fail()


### PR DESCRIPTION
Fixes https://github.com/vyperlang/titanoboa/issues/252
Moved from https://github.com/vyperlang/titanoboa/pull/259

### What I did
- Fixed KeyError

### How I did it
- By ignoring the debug frames of library errors

### How to verify it
- Test is included

### Description for the changelog
N/A

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/ddd1c8b2-c8a8-4263-828b-dca5b24bb7e0)
