### PR TITLE
downgrade vyper requirement from 0.4.0 to 0.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = ["Topic :: Software Development"]
 
 # Requirements
 dependencies = [
-    "vyper>=0.4.0",
+    "vyper>=0.3.10",
     "eth-stdlib>=0.2.7,<0.3.0",
     "eth-abi",
     "py-evm>=0.10.0b4",


### PR DESCRIPTION
### What I did

downgraded vyper requirement from 0.4.0 to 0.3.10

### How I did it

just change requirement in pyproject.toml 

### How to verify it

you can try to `poetry add curve-boa` in a repository with vyper 0.3.10 set as the requirement and it gives the following error:

```
% poetry add curve-boa
Using version ^0.2.0.0 for curve-boa

Updating dependencies
Resolving dependencies... (0.8s)

Because no versions of curve-boa match >0.2.0.0,<0.3.0.0
 and curve-boa (0.2.0.0) depends on vyper (>=0.4.0), curve-boa (>=0.2.0.0,<0.3.0.0) requires vyper (>=0.4.0).
And because titanoboa (0.1.10) depends on vyper (0.3.10), curve-boa (>=0.2.0.0,<0.3.0.0) is incompatible with titanoboa (0.1.10).
So, because curve-lite depends on both titanoboa (0.1.10) and curve-boa (^0.2.0.0), version solving failed.
```

### Description for the changelog

Set required vyper version to at least 0.3.10

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/7952db9f-01fe-424d-a10e-64827daba024)

